### PR TITLE
Tier Fixes

### DIFF
--- a/src/card_logic.py
+++ b/src/card_logic.py
@@ -78,9 +78,9 @@ class CardResult:
         """Retrieve tier list rating for this card"""
         result = "NA"
         try:
-            card_name = card[constants.DATA_FIELD_NAME].split(" // ")
-            if card_name[0] in self.tier_data[option][constants.DATA_SECTION_RATINGS]:
-                tier_data = self.tier_data[option][constants.DATA_SECTION_RATINGS][card_name[0]]
+            card_name = card[constants.DATA_FIELD_NAME].replace('///', '//')
+            if card_name in self.tier_data[option][constants.DATA_SECTION_RATINGS]:
+                tier_data = self.tier_data[option][constants.DATA_SECTION_RATINGS][card_name]
                 result = tier_data["rating"]
                 # Append an asterisk to denote a comment
                 result = "*" + result if tier_data["comment"] else result

--- a/src/overlay.py
+++ b/src/overlay.py
@@ -3239,11 +3239,8 @@ class CreateCardToolTip(ScaledWindow):
                                       wraplength=tt_width,)
                 comment_label.grid(column=0, row=0, sticky=tkinter.NSEW)
 
-                font = ImageFont.truetype('times.ttf', 12)
-                font_size = font.getsize(comment)
-                font_rows = math.ceil(font_size[0] / tt_width) + 2
-                font_height = font_rows * font_size[1]
-                tt_height += self._scale_value(font_height)
+                #Removed broken code that was used to calculate the comment height in pixels
+                
                 row_count += 1
 
             note_label.grid(column=0, row=row_count,

--- a/tests/test_card_logic.py
+++ b/tests/test_card_logic.py
@@ -1,0 +1,69 @@
+import pytest
+from src.card_logic import CardResult, SetMetrics
+from src.configuration import Configuration
+
+# Cards pulled from various tier lists that were downloaded using the chrome plugin
+TEST_TIER_LIST = {
+    "TIER0" : {
+        "meta": {
+            "collection_date": "",
+            "label": "",
+            "set": "",
+            "version": 3
+        },
+        "ratings":{
+            #Split sample
+            "Push // Pull": {
+                "rating": "C+",
+                "comment": ""
+            },
+            #Double-sided sample
+            "Etali, Primal Conqueror": {
+                "rating": "A+",
+                "comment": ""
+            },
+            #Adventure sample
+            "Virtue of Persistence": {
+                "rating": "A+",
+                "comment": ""
+            },
+            #Aftermath sample
+            "Consign // Oblivion": {
+                "rating": "C+",
+                "comment": ""
+            },
+            #Meld sample
+            "The Mightstone and Weakstone": {
+                "rating": "B-",
+                "comment": ""
+            },
+            #Battle sample
+            "Invasion of Gobakhan": {
+                "rating": "B+",
+                "comment": ""
+            },
+        }
+    }
+}
+
+@pytest.fixture
+def card_result():
+    return CardResult(SetMetrics(), TEST_TIER_LIST, Configuration(), 1)
+    
+#The card data is pulled from the JSON set files downloaded from 17Lands, excluding the fake card
+@pytest.mark.parametrize("card_list, expected_tier",[
+        ([{"name": "Push // Pull"}], "C+"),
+        ([{"name": "Consign /// Oblivion"}], "C+"),
+        ([{"name": "Etali, Primal Conqueror"}], "A+"),
+        ([{"name": "Invasion of Gobakhan"}], "B+"),
+        ([{"name": "The Mightstone and Weakstone"}], "B-"),
+        ([{"name": "Virtue of Persistence"}], "A+"),
+        ([{"name": "Fake Card"}], "NA"),
+    ]
+)
+
+def test_tier_results(card_result, card_list, expected_tier):
+    #Go through a list of non-standard cards and confirm that the CardResults class is producing the expected result
+    result_list = card_result.return_results(card_list, ["All Decks"], {"Column1" : "TIER0"})
+    
+    assert result_list[0]["results"][0] == expected_tier


### PR DESCRIPTION
Summary of the changes:
- Removed some broken code that would crash the program if a tooltip was opened for a card with tier comments
- Fixed a bug that was preventing the program from displaying tier grades for split cards

![image](https://github.com/FiYir/MTGA_Draft_17Lands/assets/151777715/b93e93bd-10d9-4a5a-bc86-0edea8565cfa)

![image](https://github.com/FiYir/MTGA_Draft_17Lands/assets/151777715/b8ab2f3c-3e32-45cd-a7bf-365e0189af84)



