### PR TITLE
Hide Unknown Cards (Basic Lands)

### DIFF
--- a/tests/test_app_update.py
+++ b/tests/test_app_update.py
@@ -36,17 +36,20 @@ def valid_input_url_exe():
 @pytest.fixture
 def output_filename():
     return "test_file.exe"
-    
+
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Skipping on macOS because of Github API rate limiting")
 def test_retrieve_file_version_latest_success(app_update, valid_search_location_latest):
     version, file_location = app_update.retrieve_file_version(valid_search_location_latest)
     assert isinstance(version, str) and isinstance(float(version), float)
     assert isinstance(file_location, str)
     assert len(file_location) != 0
-    
+
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Skipping on macOS because of Github API rate limiting")
 def test_retrieve_file_version_old_success(app_update, valid_search_location_old):
     version, file_location = app_update.retrieve_file_version(valid_search_location_old)
     assert version == EXPECTED_OLD_VERSION_STRING
-    
+
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Skipping on macOS because of Github API rate limiting")
 def test_retrieve_file_version_failure(app_update, invalid_search_location):
     version, file_location = app_update.retrieve_file_version(invalid_search_location)
     assert version == ""

--- a/tests/test_log_scanner.py
+++ b/tests/test_log_scanner.py
@@ -415,7 +415,15 @@ OTJ_TRAD_DRAFT_ENTRIES_2024_5_7 = [
 
 @pytest.fixture(name="test_scanner",scope="session")
 def fixture_test_scanner():
-    scanner = ArenaScanner(TEST_LOG_FILE_LOCATION, TEST_SETS, sets_location = TEST_LOG_DIRECTORY)
+    scanner = ArenaScanner(TEST_LOG_FILE_LOCATION, TEST_SETS, sets_location = TEST_LOG_DIRECTORY, retrieve_unknown = True)
+    scanner.log_enable(False)
+    yield scanner
+    if os.path.exists(TEST_LOG_FILE_LOCATION):
+        os.remove(TEST_LOG_FILE_LOCATION)
+        
+@pytest.fixture(name="test_scanner",scope="session")
+def fixture_test_scanner():
+    scanner = ArenaScanner(TEST_LOG_FILE_LOCATION, TEST_SETS, sets_location = TEST_LOG_DIRECTORY, retrieve_unknown = True)
     scanner.log_enable(False)
     yield scanner
     if os.path.exists(TEST_LOG_FILE_LOCATION):


### PR DESCRIPTION
Adding an optional configuration argument (retrieve_unknown) to filter out unknown cards while retrieving packs, taken cards, and missing cards.

Since 17Lands lacks data for basic lands, these cards are omitted from the dataset and treated as unknown by the tool during drafting. This update conceals these cards, preventing them from being displayed as numerical values on the UI.